### PR TITLE
Regex update - don't consume multiple comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "badger",
-  "version": "1.0.3",
+  "version": "1.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "badger",
-      "version": "1.0.3",
+      "version": "1.0.7",
       "license": "UNLICENSED",
       "dependencies": {
         "@actions/core": "^1.10.1",
@@ -2721,6 +2721,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badger",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "A GitHub action to add customised badges to pull requests.",
   "main": "index.js",
   "scripts": {

--- a/src/Badger.test.ts
+++ b/src/Badger.test.ts
@@ -261,4 +261,28 @@ This is a test body!
 
 I am a suffix!`)
   })
+
+  it('should not consume any comments in the body', () => {
+    const badger = new Badger(EMPTY_CACHE)
+    const body = `
+---
+## 🦡 Badger
+---
+
+<!---
+This is a comment in the body
+-->
+This is a test body!`
+
+    const result = badger.apply(body, undefined)
+    expect(result).toEqual(`
+<!-- Start of Badger Additions -->
+
+<!-- End of Badger Additions -->
+
+<!---
+This is a comment in the body
+-->
+This is a test body!`)
+  })
 })

--- a/src/Badger.ts
+++ b/src/Badger.ts
@@ -15,7 +15,7 @@ export default class Badger {
    */
   public apply(body: string, badges: string[] = [], prefix?: string, suffix?: string): string {
     const markdown = this.toMarkdown(this.badges(badges))
-    let updated = body.replace(/\r/g, '').replace(/(---\r?\n## 🦡 Badger\n([\s\S]+)?---)/, markdown)
+    let updated = body.replace(/\r/g, '').replace(/(---\r?\n## Badger\n([\s\S]*?)---)/, markdown)
 
     updated = this.applyPrefix(updated, prefix)
     updated = this.applySuffix(updated, suffix)

--- a/src/Badger.ts
+++ b/src/Badger.ts
@@ -15,7 +15,7 @@ export default class Badger {
    */
   public apply(body: string, badges: string[] = [], prefix?: string, suffix?: string): string {
     const markdown = this.toMarkdown(this.badges(badges))
-    let updated = body.replace(/\r/g, '').replace(/(---\r?\n## Badger\n([\s\S]*?)---)/, markdown)
+    let updated = body.replace(/\r/g, '').replace(/(---\r?\n## 🦡 Badger\n([\s\S]*?)---)/, markdown)
 
     updated = this.applyPrefix(updated, prefix)
     updated = this.applySuffix(updated, suffix)


### PR DESCRIPTION
If you have multiple `---` comments in your pr description, the badger regex would greedily eat as many as it could. This changes it to stop at the first one, and shouldn't affect the `replace` operation - although I don't really know typescript or the rest of the code, so please confirm this!

I tested this in regexr.com and it seems to behave as intended, although regex is always a risk